### PR TITLE
Drop net50 TFM and update dependencies.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,7 +130,7 @@ jobs:
     - name: Test
       id: test
       if: ${{ github.event.inputs.skip-tests != 'true' }}
-      run: ./build/test.ps1 -p ./tests/Mawosoft.MissingCoverage.Tests/Mawosoft.MissingCoverage.Tests.csproj -c Debug, Release -f netcoreapp3.1, net5.0, net6.0 -v detailed -r ./TestResults -ff:$${{ strategy.fail-fast }}
+      run: ./build/test.ps1 -p ./tests/Mawosoft.MissingCoverage.Tests/Mawosoft.MissingCoverage.Tests.csproj -c Debug, Release -f netcoreapp3.1, net6.0 -v detailed -r ./TestResults -ff:$${{ strategy.fail-fast }}
     - name: Upload Test results
       if: ${{ always() && steps.test.outcome != 'skipped' }}
       uses: actions/upload-artifact@v2

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,7 +8,7 @@
 
   <!-- TFMs for main and test projects -->
   <PropertyGroup>
-    <_MainTargetFrameworks>netcoreapp3.1;net5.0;net6.0</_MainTargetFrameworks>
+    <_MainTargetFrameworks>netcoreapp3.1;net6.0</_MainTargetFrameworks>
     <ContinuousIntegrationBuild>$(CI)</ContinuousIntegrationBuild>
     <Deterministic>$(CI)</Deterministic>
   </PropertyGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,12 +3,22 @@
   <ItemGroup>
     <PackageVersion Include="BenchmarkDotNet" Version="0.13.1" />
     <PackageVersion Include="coverlet.collector" Version="3.1.2" />
-    <PackageVersion Include="Mawosoft.Extensions.BenchmarkDotNet" Version="0.2.1" />
+    <PackageVersion Include="Mawosoft.Extensions.BenchmarkDotNet" Version="0.2.2" />
     <PackageVersion Include="Microsoft.Extensions.FileSystemGlobbing" Version="6.0.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
     <PackageVersion Include="xunit" Version="2.4.1" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.5" />
+  </ItemGroup>
+
+  <!-- Override transitive vulnerabilities in test project -->
+  <ItemGroup>
+    <!-- Ref by Microsoft.NET.Test.Sdk 17.2.0 -->
+    <PackageVersion Include="Newtonsoft.Json" Version="13.0.1" />
+    <!-- Ref by xunit 2.4.1 -->
+    <PackageVersion Include="NETStandard.Library" Version="2.0.3" />
+    <!-- <PackageVersion Include="System.Net.Http" Version="4.3.4" /> -->
+    <!-- <PackageVersion Include="System.Text.RegularExpressions" Version="4.3.1" /> -->
   </ItemGroup>
 
 </Project>

--- a/src/Mawosoft.MissingCoverage/runtimeconfig.template.json
+++ b/src/Mawosoft.MissingCoverage/runtimeconfig.template.json
@@ -1,0 +1,3 @@
+{
+    "rollForwardOnNoCandidateFx": 2
+}

--- a/tests/Mawosoft.MissingCoverage.Tests/Mawosoft.MissingCoverage.Tests.csproj
+++ b/tests/Mawosoft.MissingCoverage.Tests/Mawosoft.MissingCoverage.Tests.csproj
@@ -25,6 +25,12 @@
     </PackageReference>
   </ItemGroup>
 
+  <!-- Override transitive vulnerabilities -->
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" />
+    <PackageReference Include="NETStandard.Library" />
+  </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\src\Mawosoft.MissingCoverage\Mawosoft.MissingCoverage.csproj" />
   </ItemGroup>

--- a/tests/benchmarks/EnumBenchmarks/EnumBenchmarks.csproj
+++ b/tests/benchmarks/EnumBenchmarks/EnumBenchmarks.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/benchmarks/LineInfoBenchmarks/LineInfoBenchmarks.csproj
+++ b/tests/benchmarks/LineInfoBenchmarks/LineInfoBenchmarks.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/benchmarks/XmlBenchmarks/XmlBenchmarks.csproj
+++ b/tests/benchmarks/XmlBenchmarks/XmlBenchmarks.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Override outdated refs from xunit and Microsoft.NET.Test.Sdk to get rid of transitive vulnerabilities. Closes #32.