### PR TITLE
Drop netcoreapp3.1 TFM and update dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,7 +127,7 @@ jobs:
     - name: Test
       id: test
       if: ${{ github.event.inputs.skip-tests != 'true' }}
-      run: ./build/test.ps1 -p ./tests/Mawosoft.MissingCoverage.Tests/Mawosoft.MissingCoverage.Tests.csproj -c Debug, Release -f netcoreapp3.1, net6.0 -v detailed -r ./TestResults -ff:$${{ strategy.fail-fast }}
+      run: ./build/test.ps1 -p ./tests/Mawosoft.MissingCoverage.Tests/Mawosoft.MissingCoverage.Tests.csproj -c Debug, Release -f net6.0 -v detailed -r ./TestResults -ff:$${{ strategy.fail-fast }}
     - name: Upload Test results
       if: ${{ always() && steps.test.outcome != 'skipped' }}
       uses: actions/upload-artifact@v3

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,7 +8,7 @@
 
   <!-- TFMs for main and test projects -->
   <PropertyGroup>
-    <_MainTargetFrameworks>netcoreapp3.1;net6.0</_MainTargetFrameworks>
+    <_MainTargetFrameworks>net6.0</_MainTargetFrameworks>
     <ContinuousIntegrationBuild>$(CI)</ContinuousIntegrationBuild>
     <Deterministic>$(CI)</Deterministic>
   </PropertyGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,8 +4,8 @@
     <PackageVersion Include="BenchmarkDotNet" Version="0.13.2" />
     <PackageVersion Include="coverlet.collector" Version="3.2.0" />
     <PackageVersion Include="Mawosoft.Extensions.BenchmarkDotNet" Version="0.2.3" />
-    <PackageVersion Include="Microsoft.Extensions.FileSystemGlobbing" Version="6.0.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+    <PackageVersion Include="Microsoft.Extensions.FileSystemGlobbing" Version="7.0.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
     <PackageVersion Include="xunit" Version="2.4.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.5" />
@@ -15,7 +15,6 @@
     <!-- Transitive pinning for vulnerable packages -->
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
     <PackageVersion Include="System.Text.RegularExpressions" Version="4.3.1" />
-    <PackageVersion Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 
 </Project>

--- a/src/Mawosoft.MissingCoverage/CoberturaParser.cs
+++ b/src/Mawosoft.MissingCoverage/CoberturaParser.cs
@@ -313,9 +313,6 @@ namespace Mawosoft.MissingCoverage
                 lineNumber = xmlLineInfo.LineNumber;
                 linePosition = xmlLineInfo.LinePosition;
             }
-#if !NET5_0_OR_GREATER
-            message ??= "XML error."; // COMPAT net31 doesn't use default message if null.
-#endif
             throw new XmlException(message, innerException, lineNumber, linePosition);
         }
     }

--- a/src/Mawosoft.MissingCoverage/Options.cs
+++ b/src/Mawosoft.MissingCoverage/Options.cs
@@ -158,9 +158,7 @@ namespace Mawosoft.MissingCoverage
                     {
                         found = false; // Strings will be parsed later
                     }
-                    // COMPAT net31 doesn't have generic Enum.IsDefined<TEnum>().
-                    // PERF Non-generic method 3x slower, but shouldn't matter here.
-                    else if (Enum.IsDefined(typeof(VerbosityLevel), intVal))
+                    else if (Enum.IsDefined((VerbosityLevel)intVal))
                     {
                         Verbosity = (VerbosityLevel)intVal;
                         valid = true;
@@ -181,8 +179,7 @@ namespace Mawosoft.MissingCoverage
             switch (option)
             {
                 case "v" or "verbosity":
-                    // COMPAT net31. See notes above.
-                    if (Enum.TryParse(value, ignoreCase: true, out VerbosityLevel level) && Enum.IsDefined(typeof(VerbosityLevel), level))
+                    if (Enum.TryParse(value, ignoreCase: true, out VerbosityLevel level) && Enum.IsDefined(level))
                     {
                         Verbosity = level;
                         valid = true;

--- a/tests/Mawosoft.MissingCoverage.Tests/CoberturaParserTests.SimpleCoberturaParser.cs
+++ b/tests/Mawosoft.MissingCoverage.Tests/CoberturaParserTests.SimpleCoberturaParser.cs
@@ -37,9 +37,8 @@ namespace Mawosoft.MissingCoverage.Tests
             node = null; // Track current node for exceptions not thrown explicitly
             try
             {
-                foreach (XPathNavigator? source in navi.Select("/coverage/sources/source"))
+                foreach (XPathNavigator source in navi.Select("/coverage/sources/source"))
                 {
-                    if (source == null) continue; // COMPAT net31
                     node = source;
                     if (source.Value.Length > 0)
                     {
@@ -56,9 +55,8 @@ namespace Mawosoft.MissingCoverage.Tests
                 }
                 node = null;
 
-                foreach (XPathNavigator? @class in navi.Select(xpathClasses))
+                foreach (XPathNavigator @class in navi.Select(xpathClasses))
                 {
-                    if (@class == null) continue; // COMPAT net31
                     node = @class;
                     string fileName = @class.GetAttribute("filename", "");
                     if (fileName.Length == 0)
@@ -73,9 +71,8 @@ namespace Mawosoft.MissingCoverage.Tests
                     }
                     SourceFileInfo sourceFileInfo = new(fileName, reportTimestamp);
 
-                    foreach (XPathNavigator? line in @class.Select("lines/line"))
+                    foreach (XPathNavigator line in @class.Select("lines/line"))
                     {
-                        if (line == null) continue; // COMPAT net31
                         node = line;
                         LineInfo lineInfo = default;
                         if (!int.TryParse(line.GetAttribute("number", ""), out int lineNumber) || lineNumber < 1)
@@ -121,9 +118,6 @@ namespace Mawosoft.MissingCoverage.Tests
                     lineNumber = lineInfo.LineNumber;
                     linePosition = lineInfo.LinePosition;
                 }
-#if !NET5_0_OR_GREATER
-                message ??= "XML error."; // COMPAT net31 doesn't use default message if null.
-#endif
                 throw new XmlException(message, innerException, lineNumber, linePosition);
             }
         }

--- a/tests/Mawosoft.MissingCoverage.Tests/CoberturaParserTests.cs
+++ b/tests/Mawosoft.MissingCoverage.Tests/CoberturaParserTests.cs
@@ -32,18 +32,17 @@ namespace Mawosoft.MissingCoverage.Tests
             int pos = exception.LinePosition - fileLine.Length + (fileLine = fileLine.TrimStart()).Length;
             string[] elementLines = report.FirstInvalidElement!
                 .ToString()
-                .Split(new[] { "\r\n", "\n", "\r" }, StringSplitOptions.None);
+                .Split(new[] { "\r\n", "\n", "\r" }, StringSplitOptions.TrimEntries);
             string elementLine;
             int expectedPos;
             if (fileLine.StartsWith("</", StringComparison.Ordinal))
             {
-                // COMPAT net31 doesn't have StringSplitOptions.TrimEntries
-                elementLine = elementLines[^1].Trim();
+                elementLine = elementLines[^1];
                 expectedPos = 3;
             }
             else
             {
-                elementLine = elementLines[0].Trim();
+                elementLine = elementLines[0];
                 expectedPos = 2;
             }
 

--- a/tests/Mawosoft.MissingCoverage.Tests/ProgramTests.cs
+++ b/tests/Mawosoft.MissingCoverage.Tests/ProgramTests.cs
@@ -107,8 +107,7 @@ namespace Mawosoft.MissingCoverage.Tests
         public void WriteFileError_WithXmlException_WritesLineInfo()
         {
             RedirectWrapper wrapper = new();
-            // COMPAT net31 doesn't use default message if null.
-            Exception ex = Assert.Throws<XmlException>((Action)(static () => throw new XmlException("Xml error.", null, 7, 20)));
+            Exception ex = Assert.Throws<XmlException>((Action)(static () => throw new XmlException(null, null, 7, 20)));
             string filePath = "somedir/somefile.cs";
             wrapper.Program.WriteFileError(filePath, ex);
             AssertAppTitle(wrapper);
@@ -121,8 +120,7 @@ namespace Mawosoft.MissingCoverage.Tests
         public void WriteFileError_WithoutFilePath_WritesToolError()
         {
             RedirectWrapper wrapper = new();
-            // COMPAT net31 doesn't use default message if null.
-            Exception ex = Assert.Throws<XmlException>((Action)(static () => throw new XmlException("Xml error.", null, 7, 20)));
+            Exception ex = Assert.Throws<XmlException>((Action)(static () => throw new XmlException(null, null, 7, 20)));
             wrapper.Program.WriteFileError(null!, ex);
             AssertAppTitle(wrapper);
             string expected = "MissingCoverage : error MC9000: " + ex.Message;


### PR DESCRIPTION
- Drop netcoreapp3.1 TFM. Support ends Dec 13, 2022
Remove 'COMPAT net31' code.
- Bump Microsoft.NET.Test.Sdk to 17.4.0
Remove transitive pinning of Newtonsoft.Json (no longer necessary).
- Bump Microsoft.Extensions.FileSystemGlobbing to 7.0.0

Closes #53