### PR TITLE
Release 0.9.2

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -173,7 +173,7 @@ dotnet_code_quality.CA1822.api_surface = private, internal
 dotnet_code_quality.CA2208.api_surface = public
 
 # License header
-file_header_template = Copyright (c) 2021-2022 Matthias Wolf, Mawosoft.
+file_header_template = Copyright (c) 2021-2023 Matthias Wolf, Mawosoft.
 
 # C++ Files
 [*.{cpp,h,in}]

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -20,17 +20,14 @@
     <!-- Pinning still has some kinks. See https://github.com/NuGet/Home/issues/11952 -->
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
     <TreatWarningsAsErrors>$(CI)</TreatWarningsAsErrors>
-    <!-- Regression in .NET SDK 6.0.300 when using Central Package Management:
-         NU1507 if multiple feeds are used without package source mapping. -->
-    <NoWarn>$(NoWarn);NU1507</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup>
     <Authors>Matthias Wolf</Authors>
     <Company>Mawosoft</Company>
     <Product>Mawosoft.MissingCoverage</Product>
-    <Copyright>Copyright (c) 2021-2022 Matthias Wolf, Mawosoft</Copyright>
-    <Version>0.9.2-dev</Version>
+    <Copyright>Copyright (c) 2021-2023 Matthias Wolf, Mawosoft</Copyright>
+    <Version>0.9.2</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021-2022 Matthias Wolf
+Copyright (c) 2021-2023 Matthias Wolf
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/build/test.ps1
+++ b/build/test.ps1
@@ -1,4 +1,4 @@
-# Copyright (c) 2022 Matthias Wolf, Mawosoft.
+# Copyright (c) 2022-2023 Matthias Wolf, Mawosoft.
 
 # Run dotnet test for projects * configs * frameworks
 
@@ -91,15 +91,17 @@ foreach ($project in $Projects) {
             if (-not $Build.IsPresent) {
                 $params += "--no-build"
             }
-            $params += "-c", $config
-            $params += "-f", $framework
-            $params += "-l", "`"console;verbosity=$Verbosity`""
-            $params += "-r", "`"$currentResultsDirectory`""
-            $params += "-l", "trx"
+            # Dont't use aliases like -r, they could change (-r is now --runtime in SDK >= 7.0)
+            # See https://github.com/dotnet/sdk/issues/21952
+            $params += "--configuration", $config
+            $params += "--framework", $framework
+            $params += "--logger", "`"console;verbosity=$Verbosity`""
+            $params += "--results-directory", "`"$currentResultsDirectory`""
+            $params += "--logger", "trx"
             if ($CodeCoverage.IsPresent -or $Settings -ne "") {
                 $params += "--collect", "`"XPlat Code Coverage`""
                 if ($Settings -ne "") {
-                    $params += "-s", "`"$Settings`""
+                    $params += "--settings", "`"$Settings`""
                 }
             }
             $params += "--diag", "`"$(Join-Path $currentResultsDirectory "diag.log")`""

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "6.0.403",
+    "version": "7.0.102",
     "rollForward": "latestMinor"
   }
 }

--- a/src/Mawosoft.MissingCoverage/CoberturaParser.cs
+++ b/src/Mawosoft.MissingCoverage/CoberturaParser.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021-2022 Matthias Wolf, Mawosoft.
+﻿// Copyright (c) 2021-2023 Matthias Wolf, Mawosoft.
 
 using System;
 using System.Collections.Generic;

--- a/src/Mawosoft.MissingCoverage/CoverageResult.cs
+++ b/src/Mawosoft.MissingCoverage/CoverageResult.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021-2022 Matthias Wolf, Mawosoft.
+﻿// Copyright (c) 2021-2023 Matthias Wolf, Mawosoft.
 
 using System;
 using System.Collections.Generic;

--- a/src/Mawosoft.MissingCoverage/LineInfo.cs
+++ b/src/Mawosoft.MissingCoverage/LineInfo.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021-2022 Matthias Wolf, Mawosoft.
+﻿// Copyright (c) 2021-2023 Matthias Wolf, Mawosoft.
 
 using System;
 using System.Diagnostics.CodeAnalysis;

--- a/src/Mawosoft.MissingCoverage/Mawosoft.MissingCoverage.csproj
+++ b/src/Mawosoft.MissingCoverage/Mawosoft.MissingCoverage.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(_MainTargetFrameworks)</TargetFrameworks>
     <OutputType>Exe</OutputType>
+    <RollForward>Major</RollForward>
     <NeutralLanguage>en-US</NeutralLanguage>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>

--- a/src/Mawosoft.MissingCoverage/OptionValue.cs
+++ b/src/Mawosoft.MissingCoverage/OptionValue.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021-2022 Matthias Wolf, Mawosoft.
+﻿// Copyright (c) 2021-2023 Matthias Wolf, Mawosoft.
 
 namespace Mawosoft.MissingCoverage
 {

--- a/src/Mawosoft.MissingCoverage/Options.cs
+++ b/src/Mawosoft.MissingCoverage/Options.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021-2022 Matthias Wolf, Mawosoft.
+﻿// Copyright (c) 2021-2023 Matthias Wolf, Mawosoft.
 
 using System;
 using System.Collections.Generic;

--- a/src/Mawosoft.MissingCoverage/Program.cs
+++ b/src/Mawosoft.MissingCoverage/Program.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021-2022 Matthias Wolf, Mawosoft.
+﻿// Copyright (c) 2021-2023 Matthias Wolf, Mawosoft.
 
 using System;
 using System.Collections.Generic;

--- a/src/Mawosoft.MissingCoverage/SourceFileInfo.cs
+++ b/src/Mawosoft.MissingCoverage/SourceFileInfo.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021-2022 Matthias Wolf, Mawosoft.
+﻿// Copyright (c) 2021-2023 Matthias Wolf, Mawosoft.
 
 using System;
 using System.Collections.Generic;

--- a/src/Mawosoft.MissingCoverage/VerbosityLevel.cs
+++ b/src/Mawosoft.MissingCoverage/VerbosityLevel.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021-2022 Matthias Wolf, Mawosoft.
+﻿// Copyright (c) 2021-2023 Matthias Wolf, Mawosoft.
 
 namespace Mawosoft.MissingCoverage
 {

--- a/src/Mawosoft.MissingCoverage/runtimeconfig.template.json
+++ b/src/Mawosoft.MissingCoverage/runtimeconfig.template.json
@@ -1,3 +1,0 @@
-{
-    "rollForwardOnNoCandidateFx": 2
-}

--- a/tests/Mawosoft.MissingCoverage.Tests/ArgumentCell.cs
+++ b/tests/Mawosoft.MissingCoverage.Tests/ArgumentCell.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021-2022 Matthias Wolf, Mawosoft.
+﻿// Copyright (c) 2021-2023 Matthias Wolf, Mawosoft.
 
 using System.Collections.Generic;
 using System.Reflection;

--- a/tests/Mawosoft.MissingCoverage.Tests/ArgumentColumn.cs
+++ b/tests/Mawosoft.MissingCoverage.Tests/ArgumentColumn.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021-2022 Matthias Wolf, Mawosoft.
+﻿// Copyright (c) 2021-2023 Matthias Wolf, Mawosoft.
 
 using System.Collections.Generic;
 using System.Linq;

--- a/tests/Mawosoft.MissingCoverage.Tests/ArgumentInfo.cs
+++ b/tests/Mawosoft.MissingCoverage.Tests/ArgumentInfo.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021-2022 Matthias Wolf, Mawosoft.
+﻿// Copyright (c) 2021-2023 Matthias Wolf, Mawosoft.
 
 using System.Collections.Generic;
 using System.Reflection;

--- a/tests/Mawosoft.MissingCoverage.Tests/ArgumentMatrix.cs
+++ b/tests/Mawosoft.MissingCoverage.Tests/ArgumentMatrix.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021-2022 Matthias Wolf, Mawosoft.
+﻿// Copyright (c) 2021-2023 Matthias Wolf, Mawosoft.
 
 using System.Collections.Generic;
 using System.Linq;

--- a/tests/Mawosoft.MissingCoverage.Tests/ArgumentMutations.cs
+++ b/tests/Mawosoft.MissingCoverage.Tests/ArgumentMutations.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021-2022 Matthias Wolf, Mawosoft.
+﻿// Copyright (c) 2021-2023 Matthias Wolf, Mawosoft.
 
 using System;
 

--- a/tests/Mawosoft.MissingCoverage.Tests/ArgumentRow.cs
+++ b/tests/Mawosoft.MissingCoverage.Tests/ArgumentRow.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021-2022 Matthias Wolf, Mawosoft.
+﻿// Copyright (c) 2021-2023 Matthias Wolf, Mawosoft.
 
 using System.Collections.Generic;
 using System.Linq;

--- a/tests/Mawosoft.MissingCoverage.Tests/CoberturaParserTests.SimpleCoberturaParser.cs
+++ b/tests/Mawosoft.MissingCoverage.Tests/CoberturaParserTests.SimpleCoberturaParser.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021-2022 Matthias Wolf, Mawosoft.
+﻿// Copyright (c) 2021-2023 Matthias Wolf, Mawosoft.
 
 using System;
 using System.Collections.Generic;

--- a/tests/Mawosoft.MissingCoverage.Tests/CoberturaParserTests.cs
+++ b/tests/Mawosoft.MissingCoverage.Tests/CoberturaParserTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021-2022 Matthias Wolf, Mawosoft.
+﻿// Copyright (c) 2021-2023 Matthias Wolf, Mawosoft.
 
 using System;
 using System.Collections.Generic;

--- a/tests/Mawosoft.MissingCoverage.Tests/CoberturaReportBuilder.cs
+++ b/tests/Mawosoft.MissingCoverage.Tests/CoberturaReportBuilder.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021-2022 Matthias Wolf, Mawosoft.
+﻿// Copyright (c) 2021-2023 Matthias Wolf, Mawosoft.
 
 using System;
 using System.Collections.Generic;

--- a/tests/Mawosoft.MissingCoverage.Tests/CoverageResultTests.cs
+++ b/tests/Mawosoft.MissingCoverage.Tests/CoverageResultTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021-2022 Matthias Wolf, Mawosoft.
+﻿// Copyright (c) 2021-2023 Matthias Wolf, Mawosoft.
 
 using System;
 using System.Collections.Generic;

--- a/tests/Mawosoft.MissingCoverage.Tests/LineInfoMergeData.cs
+++ b/tests/Mawosoft.MissingCoverage.Tests/LineInfoMergeData.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021-2022 Matthias Wolf, Mawosoft.
+﻿// Copyright (c) 2021-2023 Matthias Wolf, Mawosoft.
 
 using System.Collections.Generic;
 using System.Reflection;

--- a/tests/Mawosoft.MissingCoverage.Tests/LineInfoTests.cs
+++ b/tests/Mawosoft.MissingCoverage.Tests/LineInfoTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021-2022 Matthias Wolf, Mawosoft.
+﻿// Copyright (c) 2021-2023 Matthias Wolf, Mawosoft.
 
 using System;
 using Xunit;

--- a/tests/Mawosoft.MissingCoverage.Tests/NoParallelTests.cs
+++ b/tests/Mawosoft.MissingCoverage.Tests/NoParallelTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021-2022 Matthias Wolf, Mawosoft.
+﻿// Copyright (c) 2021-2023 Matthias Wolf, Mawosoft.
 
 using Xunit;
 

--- a/tests/Mawosoft.MissingCoverage.Tests/OptionValueTests.cs
+++ b/tests/Mawosoft.MissingCoverage.Tests/OptionValueTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021-2022 Matthias Wolf, Mawosoft.
+﻿// Copyright (c) 2021-2023 Matthias Wolf, Mawosoft.
 
 using System;
 using System.Diagnostics.CodeAnalysis;

--- a/tests/Mawosoft.MissingCoverage.Tests/OptionsTestHelper.cs
+++ b/tests/Mawosoft.MissingCoverage.Tests/OptionsTestHelper.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021-2022 Matthias Wolf, Mawosoft.
+﻿// Copyright (c) 2021-2023 Matthias Wolf, Mawosoft.
 
 using System;
 using System.Collections.Generic;

--- a/tests/Mawosoft.MissingCoverage.Tests/OptionsTests.cs
+++ b/tests/Mawosoft.MissingCoverage.Tests/OptionsTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021-2022 Matthias Wolf, Mawosoft.
+﻿// Copyright (c) 2021-2023 Matthias Wolf, Mawosoft.
 
 using System;
 using System.Collections.Generic;

--- a/tests/Mawosoft.MissingCoverage.Tests/ProgramTestHelper.cs
+++ b/tests/Mawosoft.MissingCoverage.Tests/ProgramTestHelper.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021-2022 Matthias Wolf, Mawosoft.
+﻿// Copyright (c) 2021-2023 Matthias Wolf, Mawosoft.
 
 using System;
 using System.Collections.Generic;

--- a/tests/Mawosoft.MissingCoverage.Tests/ProgramTests.Configure.cs
+++ b/tests/Mawosoft.MissingCoverage.Tests/ProgramTests.Configure.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2022 Matthias Wolf, Mawosoft.
+// Copyright (c) 2021-2023 Matthias Wolf, Mawosoft.
 
 using System.IO;
 using System.Linq;

--- a/tests/Mawosoft.MissingCoverage.Tests/ProgramTests.GetInputFiles.cs
+++ b/tests/Mawosoft.MissingCoverage.Tests/ProgramTests.GetInputFiles.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2022 Matthias Wolf, Mawosoft.
+// Copyright (c) 2021-2023 Matthias Wolf, Mawosoft.
 
 using System;
 using System.Collections.Generic;

--- a/tests/Mawosoft.MissingCoverage.Tests/ProgramTests.ProcessInputFiles.cs
+++ b/tests/Mawosoft.MissingCoverage.Tests/ProgramTests.ProcessInputFiles.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2022 Matthias Wolf, Mawosoft.
+// Copyright (c) 2021-2023 Matthias Wolf, Mawosoft.
 
 using System;
 using System.Collections.Generic;

--- a/tests/Mawosoft.MissingCoverage.Tests/ProgramTests.Run.cs
+++ b/tests/Mawosoft.MissingCoverage.Tests/ProgramTests.Run.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2022 Matthias Wolf, Mawosoft.
+// Copyright (c) 2021-2023 Matthias Wolf, Mawosoft.
 
 using System;
 using System.Collections.Generic;

--- a/tests/Mawosoft.MissingCoverage.Tests/ProgramTests.WriteResults.cs
+++ b/tests/Mawosoft.MissingCoverage.Tests/ProgramTests.WriteResults.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2022 Matthias Wolf, Mawosoft.
+// Copyright (c) 2021-2023 Matthias Wolf, Mawosoft.
 
 using System;
 using Xunit;

--- a/tests/Mawosoft.MissingCoverage.Tests/ProgramTests.cs
+++ b/tests/Mawosoft.MissingCoverage.Tests/ProgramTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021-2022 Matthias Wolf, Mawosoft.
+﻿// Copyright (c) 2021-2023 Matthias Wolf, Mawosoft.
 
 using System;
 using System.Xml;

--- a/tests/Mawosoft.MissingCoverage.Tests/RedirectWrapper.cs
+++ b/tests/Mawosoft.MissingCoverage.Tests/RedirectWrapper.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021-2022 Matthias Wolf, Mawosoft.
+﻿// Copyright (c) 2021-2023 Matthias Wolf, Mawosoft.
 
 using System;
 using System.Collections;

--- a/tests/Mawosoft.MissingCoverage.Tests/RingEnumerator.cs
+++ b/tests/Mawosoft.MissingCoverage.Tests/RingEnumerator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021-2022 Matthias Wolf, Mawosoft.
+﻿// Copyright (c) 2021-2023 Matthias Wolf, Mawosoft.
 
 using System;
 using System.Collections;

--- a/tests/Mawosoft.MissingCoverage.Tests/SourceFileInfoTests.cs
+++ b/tests/Mawosoft.MissingCoverage.Tests/SourceFileInfoTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021-2022 Matthias Wolf, Mawosoft.
+﻿// Copyright (c) 2021-2023 Matthias Wolf, Mawosoft.
 
 using System;
 using System.Collections.Generic;

--- a/tests/Mawosoft.MissingCoverage.Tests/TempDirectory.cs
+++ b/tests/Mawosoft.MissingCoverage.Tests/TempDirectory.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021-2022 Matthias Wolf, Mawosoft.
+﻿// Copyright (c) 2021-2023 Matthias Wolf, Mawosoft.
 
 // Based on:
 // - Mawosoft.ImdbScrape.Http.Tests.MockCacheDirectory

--- a/tests/Mawosoft.MissingCoverage.Tests/TempFile.cs
+++ b/tests/Mawosoft.MissingCoverage.Tests/TempFile.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021-2022 Matthias Wolf, Mawosoft.
+﻿// Copyright (c) 2021-2023 Matthias Wolf, Mawosoft.
 
 // Based on:
 // - Mawosoft.ImdbScrape.Http.Tests.MockCacheDirectory

--- a/tests/benchmarks/EnumBenchmarks/Program.cs
+++ b/tests/benchmarks/EnumBenchmarks/Program.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021-2022 Matthias Wolf, Mawosoft.
+﻿// Copyright (c) 2021-2023 Matthias Wolf, Mawosoft.
 
 using System;
 using System.Diagnostics;

--- a/tests/benchmarks/LineInfoBenchmarks/ArrayExtensions.cs
+++ b/tests/benchmarks/LineInfoBenchmarks/ArrayExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021-2022 Matthias Wolf, Mawosoft.
+﻿// Copyright (c) 2021-2023 Matthias Wolf, Mawosoft.
 
 using System;
 using System.Runtime.CompilerServices;

--- a/tests/benchmarks/LineInfoBenchmarks/Benchmarks.Array_Hits_Dictionary_BranchInfo.cs
+++ b/tests/benchmarks/LineInfoBenchmarks/Benchmarks.Array_Hits_Dictionary_BranchInfo.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021-2022 Matthias Wolf, Mawosoft.
+﻿// Copyright (c) 2021-2023 Matthias Wolf, Mawosoft.
 
 using System.Collections.Generic;
 using BenchmarkDotNet.Attributes;

--- a/tests/benchmarks/LineInfoBenchmarks/Benchmarks.Array_LineInfo.cs
+++ b/tests/benchmarks/LineInfoBenchmarks/Benchmarks.Array_LineInfo.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021-2022 Matthias Wolf, Mawosoft.
+﻿// Copyright (c) 2021-2023 Matthias Wolf, Mawosoft.
 
 using System.Collections.Generic;
 using BenchmarkDotNet.Attributes;

--- a/tests/benchmarks/LineInfoBenchmarks/Benchmarks.Dictionary_LineInfo.cs
+++ b/tests/benchmarks/LineInfoBenchmarks/Benchmarks.Dictionary_LineInfo.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021-2022 Matthias Wolf, Mawosoft.
+﻿// Copyright (c) 2021-2023 Matthias Wolf, Mawosoft.
 
 using System.Collections.Generic;
 using BenchmarkDotNet.Attributes;

--- a/tests/benchmarks/LineInfoBenchmarks/Benchmarks.SortedDictionary_LineInfo.cs
+++ b/tests/benchmarks/LineInfoBenchmarks/Benchmarks.SortedDictionary_LineInfo.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021-2022 Matthias Wolf, Mawosoft.
+﻿// Copyright (c) 2021-2023 Matthias Wolf, Mawosoft.
 
 using System.Collections.Generic;
 using BenchmarkDotNet.Attributes;

--- a/tests/benchmarks/LineInfoBenchmarks/Benchmarks.SortedList_LineInfo.cs
+++ b/tests/benchmarks/LineInfoBenchmarks/Benchmarks.SortedList_LineInfo.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021-2022 Matthias Wolf, Mawosoft.
+﻿// Copyright (c) 2021-2023 Matthias Wolf, Mawosoft.
 
 using System.Collections.Generic;
 using BenchmarkDotNet.Attributes;

--- a/tests/benchmarks/LineInfoBenchmarks/Benchmarks.cs
+++ b/tests/benchmarks/LineInfoBenchmarks/Benchmarks.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021-2022 Matthias Wolf, Mawosoft.
+﻿// Copyright (c) 2021-2023 Matthias Wolf, Mawosoft.
 
 using System;
 using System.Collections.Generic;

--- a/tests/benchmarks/LineInfoBenchmarks/FileInfoModels.cs
+++ b/tests/benchmarks/LineInfoBenchmarks/FileInfoModels.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021-2022 Matthias Wolf, Mawosoft.
+﻿// Copyright (c) 2021-2023 Matthias Wolf, Mawosoft.
 
 using System;
 using System.Collections.Generic;

--- a/tests/benchmarks/LineInfoBenchmarks/LineInfoEqualsSequenceEnumBenchmarks.cs
+++ b/tests/benchmarks/LineInfoBenchmarks/LineInfoEqualsSequenceEnumBenchmarks.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021-2022 Matthias Wolf, Mawosoft.
+﻿// Copyright (c) 2021-2023 Matthias Wolf, Mawosoft.
 
 using System;
 using System.Collections.Generic;

--- a/tests/benchmarks/LineInfoBenchmarks/LineInfoModels.cs
+++ b/tests/benchmarks/LineInfoBenchmarks/LineInfoModels.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021-2022 Matthias Wolf, Mawosoft.
+﻿// Copyright (c) 2021-2023 Matthias Wolf, Mawosoft.
 
 using System;
 

--- a/tests/benchmarks/LineInfoBenchmarks/ParamGroupOrderer.cs
+++ b/tests/benchmarks/LineInfoBenchmarks/ParamGroupOrderer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021-2022 Matthias Wolf, Mawosoft.
+﻿// Copyright (c) 2021-2023 Matthias Wolf, Mawosoft.
 
 using System;
 using System.Collections.Generic;

--- a/tests/benchmarks/LineInfoBenchmarks/Program.cs
+++ b/tests/benchmarks/LineInfoBenchmarks/Program.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021-2022 Matthias Wolf, Mawosoft.
+﻿// Copyright (c) 2021-2023 Matthias Wolf, Mawosoft.
 
 using System.Diagnostics;
 using System.Globalization;

--- a/tests/benchmarks/LineInfoBenchmarks/TestDataAnalyser.cs
+++ b/tests/benchmarks/LineInfoBenchmarks/TestDataAnalyser.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021-2022 Matthias Wolf, Mawosoft.
+﻿// Copyright (c) 2021-2023 Matthias Wolf, Mawosoft.
 
 using System;
 using System.Collections.Generic;

--- a/tests/benchmarks/LineInfoBenchmarks/TestDataSource.cs
+++ b/tests/benchmarks/LineInfoBenchmarks/TestDataSource.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021-2022 Matthias Wolf, Mawosoft.
+﻿// Copyright (c) 2021-2023 Matthias Wolf, Mawosoft.
 
 using System;
 using System.Collections.Generic;

--- a/tests/benchmarks/LineInfoBenchmarks/TestDataStats.cs
+++ b/tests/benchmarks/LineInfoBenchmarks/TestDataStats.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021-2022 Matthias Wolf, Mawosoft.
+﻿// Copyright (c) 2021-2023 Matthias Wolf, Mawosoft.
 
 using System;
 using System.Collections.Generic;

--- a/tests/benchmarks/XmlBenchmarks/CoberturaFileInfo.cs
+++ b/tests/benchmarks/XmlBenchmarks/CoberturaFileInfo.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021-2022 Matthias Wolf, Mawosoft.
+﻿// Copyright (c) 2021-2023 Matthias Wolf, Mawosoft.
 
 using System;
 using System.Collections.Generic;

--- a/tests/benchmarks/XmlBenchmarks/FileParamWrapper.cs
+++ b/tests/benchmarks/XmlBenchmarks/FileParamWrapper.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021-2022 Matthias Wolf, Mawosoft.
+﻿// Copyright (c) 2021-2023 Matthias Wolf, Mawosoft.
 
 using System.IO;
 using Mawosoft.Extensions.BenchmarkDotNet;

--- a/tests/benchmarks/XmlBenchmarks/Program.cs
+++ b/tests/benchmarks/XmlBenchmarks/Program.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021-2022 Matthias Wolf, Mawosoft.
+﻿// Copyright (c) 2021-2023 Matthias Wolf, Mawosoft.
 
 using System;
 using System.Collections.Generic;

--- a/tests/benchmarks/XmlBenchmarks/TestFiles.cs
+++ b/tests/benchmarks/XmlBenchmarks/TestFiles.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021-2022 Matthias Wolf, Mawosoft.
+﻿// Copyright (c) 2021-2023 Matthias Wolf, Mawosoft.
 
 using System;
 using System.Collections.Generic;

--- a/tests/benchmarks/XmlBenchmarks/XPathCompileBenchmarks.cs
+++ b/tests/benchmarks/XmlBenchmarks/XPathCompileBenchmarks.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021-2022 Matthias Wolf, Mawosoft.
+﻿// Copyright (c) 2021-2023 Matthias Wolf, Mawosoft.
 
 using System.Collections.Generic;
 using System.Xml.XPath;

--- a/tests/benchmarks/XmlBenchmarks/XmlLoadAndParseBenchmarks.cs
+++ b/tests/benchmarks/XmlBenchmarks/XmlLoadAndParseBenchmarks.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021-2022 Matthias Wolf, Mawosoft.
+﻿// Copyright (c) 2021-2023 Matthias Wolf, Mawosoft.
 
 using System;
 using System.Collections.Generic;

--- a/tests/benchmarks/XmlBenchmarks/XmlLoadBenchmarks.cs
+++ b/tests/benchmarks/XmlBenchmarks/XmlLoadBenchmarks.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021-2022 Matthias Wolf, Mawosoft.
+﻿// Copyright (c) 2021-2023 Matthias Wolf, Mawosoft.
 
 using System.Collections.Generic;
 using System.IO;

--- a/tests/benchmarks/XmlBenchmarks/XmlMicroBenchmarks.cs
+++ b/tests/benchmarks/XmlBenchmarks/XmlMicroBenchmarks.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021-2022 Matthias Wolf, Mawosoft.
+﻿// Copyright (c) 2021-2023 Matthias Wolf, Mawosoft.
 
 using System.Collections.Generic;
 using System.IO;

--- a/tests/benchmarks/XmlBenchmarks/XmlParseOnlyBenchmarks.cs
+++ b/tests/benchmarks/XmlBenchmarks/XmlParseOnlyBenchmarks.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021-2022 Matthias Wolf, Mawosoft.
+﻿// Copyright (c) 2021-2023 Matthias Wolf, Mawosoft.
 
 using System;
 using System.Collections.Generic;

--- a/tests/testdata/src/TestDataDirectory.cs
+++ b/tests/testdata/src/TestDataDirectory.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021-2022 Matthias Wolf, Mawosoft.
+﻿// Copyright (c) 2021-2023 Matthias Wolf, Mawosoft.
 
 using System.Runtime.CompilerServices;
 


### PR DESCRIPTION
* Release v0.9.2
  - Finalize targeting net6.0 with RollForward=Major (use MSBuild property instead of rollForwardOnNoCandidateFx)
  - Use dotnet SDK >= 7.0.2
  - Fix test.ps1 for breaking change in SDK 7.0 (see https://github.com/dotnet/sdk/issues/21952)
* Update copyright year