### PR TITLE
Update dependencies

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,11 +1,11 @@
 <Project>
 
   <ItemGroup>
-    <PackageVersion Include="BenchmarkDotNet" Version="0.13.2" />
-    <PackageVersion Include="coverlet.collector" Version="3.2.0" />
-    <PackageVersion Include="Mawosoft.Extensions.BenchmarkDotNet" Version="0.2.3" />
+    <PackageVersion Include="BenchmarkDotNet" Version="0.13.5" />
+    <PackageVersion Include="coverlet.collector" Version="6.0.0" />
+    <PackageVersion Include="Mawosoft.Extensions.BenchmarkDotNet" Version="0.2.4" />
     <PackageVersion Include="Microsoft.Extensions.FileSystemGlobbing" Version="7.0.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.6.2" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
     <PackageVersion Include="xunit" Version="2.4.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.5" />

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "7.0.102",
+    "version": "7.0.203",
     "rollForward": "latestMinor"
   }
 }

--- a/tests/benchmarks/LineInfoBenchmarks/ParamGroupOrderer.cs
+++ b/tests/benchmarks/LineInfoBenchmarks/ParamGroupOrderer.cs
@@ -34,12 +34,12 @@ namespace LineInfoBenchmarks
         public bool SeparateLogicalGroups => _inner.SeparateLogicalGroups;
 
         public IEnumerable<BenchmarkCase> GetExecutionOrder(ImmutableArray<BenchmarkCase> benchmarksCase, IEnumerable<BenchmarkLogicalGroupRule> order) => _inner.GetExecutionOrder(benchmarksCase, order);
-        public string GetHighlightGroupKey(BenchmarkCase benchmarkCase)
+        public string? GetHighlightGroupKey(BenchmarkCase benchmarkCase)
             => benchmarkCase.Parameters.Items.FirstOrDefault(
                    p => p.Name.Equals("group", StringComparison.OrdinalIgnoreCase))?.Value?.ToString()
                ?? _inner.GetHighlightGroupKey(benchmarkCase);
 
-        public string GetLogicalGroupKey(ImmutableArray<BenchmarkCase> allBenchmarksCases, BenchmarkCase benchmarkCase)
+        public string? GetLogicalGroupKey(ImmutableArray<BenchmarkCase> allBenchmarksCases, BenchmarkCase benchmarkCase)
             => benchmarkCase.Parameters.Items.FirstOrDefault(
                    p => p.Name.Equals("group", StringComparison.OrdinalIgnoreCase))?.Value?.ToString()
                ?? _inner.GetLogicalGroupKey(allBenchmarksCases, benchmarkCase);


### PR DESCRIPTION
- Use dotnet sdk >= 7.0.203
- Bump coverlet.collector to 6.0.0. Closes #70.
- Bump Microsoft.NET.Test.Sdk to 17.6.2. Closes #71, closes #72.
- Bump Mawosoft.Extensions.BenchmarkDotNet to 0.2.4.
- Bump BenchmarkDotNet to 0.13.5.
- Adjust for Nullability changes in BDN.