### PR TITLE
Bump dotnet SDK and package dependencies.

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,20 +1,14 @@
 <Project>
 
   <ItemGroup>
-    <PackageVersion Include="BenchmarkDotNet" Version="0.13.8" />
-    <PackageVersion Include="coverlet.collector" Version="6.0.0" />
+    <PackageVersion Include="BenchmarkDotNet" Version="0.13.12" />
+    <PackageVersion Include="coverlet.collector" Version="6.0.2" />
     <PackageVersion Include="Mawosoft.Extensions.BenchmarkDotNet" Version="0.2.6" />
-    <PackageVersion Include="Microsoft.Extensions.FileSystemGlobbing" Version="7.0.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
-    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
-    <PackageVersion Include="xunit" Version="2.5.1" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.1" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <!-- Transitive pinning for vulnerable packages -->
-    <PackageVersion Include="System.Net.Http" Version="4.3.4" />
-    <PackageVersion Include="System.Text.RegularExpressions" Version="4.3.1" />
+    <PackageVersion Include="Microsoft.Extensions.FileSystemGlobbing" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
+    <PackageVersion Include="xunit" Version="2.7.0" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.7" />
   </ItemGroup>
 
 </Project>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "7.0.401",
+    "version": "8.0.202",
     "rollForward": "disable"
   }
 }

--- a/src/Mawosoft.MissingCoverage/CoberturaParser.cs
+++ b/src/Mawosoft.MissingCoverage/CoberturaParser.cs
@@ -16,7 +16,7 @@ internal sealed class CoberturaParser : IDisposable
         Async = false, // Explicit for clarity
     };
 
-    private class XmlLineInfo : IXmlLineInfo
+    private sealed class XmlLineInfo : IXmlLineInfo
     {
         public int LineNumber { get; private set; }
         public int LinePosition { get; private set; }
@@ -60,7 +60,7 @@ internal sealed class CoberturaParser : IDisposable
         ReportFilePath = reportFilePath;
         ReportTimestamp = File.GetLastWriteTimeUtc(ReportFilePath);
         _xmlReader = XmlReader.Create(ReportFilePath, xmlReaderSettings);
-        _sourceDirectories = new();
+        _sourceDirectories = [];
     }
 
     [SuppressMessage("Maintainability", "CA1508:Avoid dead conditional code", Justification = "TODO false positive?")]

--- a/src/Mawosoft.MissingCoverage/CoverageResult.cs
+++ b/src/Mawosoft.MissingCoverage/CoverageResult.cs
@@ -5,7 +5,7 @@ namespace Mawosoft.MissingCoverage;
 internal sealed class CoverageResult
 {
     public bool LatestOnly { get; }
-    public List<string> ReportFilePaths { get; } = new();
+    public List<string> ReportFilePaths { get; } = [];
     public Dictionary<string, SourceFileInfo> SourceFiles { get; } = new(StringComparer.OrdinalIgnoreCase);
 
     public CoverageResult() { }
@@ -23,10 +23,7 @@ internal sealed class CoverageResult
 
     public void AddOrMergeSourceFile(SourceFileInfo sourceFile)
     {
-        if (sourceFile == null)
-        {
-            throw new ArgumentNullException(nameof(sourceFile));
-        }
+        ArgumentNullException.ThrowIfNull(sourceFile);
         if (SourceFiles.TryGetValue(sourceFile.SourceFilePath, out SourceFileInfo? existing))
         {
             if (LatestOnly)

--- a/src/Mawosoft.MissingCoverage/OptionValue.cs
+++ b/src/Mawosoft.MissingCoverage/OptionValue.cs
@@ -3,9 +3,9 @@
 namespace Mawosoft.MissingCoverage;
 
 [SuppressMessage("Performance", "CA1815:Override equals and operator equals on value types", Justification = "Not needed.")]
-internal struct OptionValue<T>
+internal struct OptionValue<T>(T defaultValue)
 {
-    private T _value;
+    private T _value = defaultValue;
 
     public T Value
     {
@@ -17,13 +17,7 @@ internal struct OptionValue<T>
         }
     }
 
-    public bool IsSet { get; private set; }
-
-    public OptionValue(T defaultValue)
-    {
-        _value = defaultValue;
-        IsSet = false;
-    }
+    public bool IsSet { get; private set; } = false;
 
     public override readonly string ToString() => _value?.ToString() + (IsSet ? "!" : "");
 

--- a/src/Mawosoft.MissingCoverage/Options.cs
+++ b/src/Mawosoft.MissingCoverage/Options.cs
@@ -17,7 +17,7 @@ internal sealed class Options
     public OptionValue<int> MaxLineNumber { get; set; } = new(50_000);
     public OptionValue<bool> NoLogo { get; set; }
     public OptionValue<VerbosityLevel> Verbosity { get; set; } = new(VerbosityLevel.Normal);
-    public List<string> GlobPatterns { get; } = new();
+    public List<string> GlobPatterns { get; } = [];
 
     public void ParseCommandLineArguments(string[] args)
     {
@@ -31,7 +31,7 @@ internal sealed class Options
             return;
         }
 
-        char[] valueSeparators = { ':', '=' };
+        char[] valueSeparators = [':', '='];
         bool canHaveOptions = true;
 
         for (int i = 0; i < args.Length; i++)

--- a/src/Mawosoft.MissingCoverage/Program.cs
+++ b/src/Mawosoft.MissingCoverage/Program.cs
@@ -81,15 +81,15 @@ internal sealed class Program
 
     }
 
-    internal IEnumerable<string> GetInputFiles()
+    internal List<string> GetInputFiles()
     {
         if (_exitCode != 0)
         {
-            return Array.Empty<string>();
+            return [];
         }
 
-        List<string> inputFilePaths = new();
-        HashSet<string> uniqueInputs = new();
+        List<string> inputFilePaths = [];
+        HashSet<string> uniqueInputs = [];
         Matcher? matcher = null;
         string lastRoot = string.Empty;
         foreach (string arg in Options.GlobPatterns)

--- a/src/Mawosoft.MissingCoverage/SourceFileInfo.cs
+++ b/src/Mawosoft.MissingCoverage/SourceFileInfo.cs
@@ -2,7 +2,7 @@
 
 namespace Mawosoft.MissingCoverage;
 
-internal sealed class SourceFileInfo
+internal sealed class SourceFileInfo(string sourceFilePath, DateTime reportTimestamp)
 {
     private static int s_defaultLineCount = 500;
     private static int s_maxLineNumber = 50_000;
@@ -23,8 +23,10 @@ internal sealed class SourceFileInfo
             : throw new ArgumentOutOfRangeException(nameof(MaxLineNumber));
     }
 
-    private string _sourceFilePath;
-    private LineInfo[] _lines;
+    private string _sourceFilePath = !string.IsNullOrWhiteSpace(sourceFilePath)
+                        ? sourceFilePath
+                        : throw new ArgumentException(null, nameof(sourceFilePath));
+    private LineInfo[] _lines = new LineInfo[DefaultLineCount];
 
     public string SourceFilePath
     {
@@ -34,19 +36,9 @@ internal sealed class SourceFileInfo
             : throw new ArgumentException(null, nameof(SourceFilePath));
     }
 
-    public DateTime ReportTimestamp { get; internal set; }
+    public DateTime ReportTimestamp { get; internal set; } = reportTimestamp;
     public int LastLineNumber { get; private set; }
     public ref readonly LineInfo Line(int index) => ref _lines[index];
-
-    public SourceFileInfo(string sourceFilePath, DateTime reportTimestamp)
-    {
-        _sourceFilePath = !string.IsNullOrWhiteSpace(sourceFilePath)
-                        ? sourceFilePath
-                        : throw new ArgumentException(null, nameof(sourceFilePath));
-        ReportTimestamp = reportTimestamp;
-        LastLineNumber = 0;
-        _lines = new LineInfo[DefaultLineCount];
-    }
 
     public override string ToString()
         => $"{SourceFilePath} ({LastLineNumber}) [{ReportTimestamp}]";
@@ -86,10 +78,7 @@ internal sealed class SourceFileInfo
 
     public void Merge(SourceFileInfo other)
     {
-        if (other == null)
-        {
-            throw new ArgumentNullException(nameof(other));
-        }
+        ArgumentNullException.ThrowIfNull(other);
         Debug.Assert(SourceFilePath == other.SourceFilePath, "SourceFilePath should be identical");
         if (other.LastLineNumber >= _lines.Length)
         {

--- a/tests/Mawosoft.MissingCoverage.Tests/.globalconfig
+++ b/tests/Mawosoft.MissingCoverage.Tests/.globalconfig
@@ -29,5 +29,8 @@ dotnet_diagnostic.CA1812.severity = none
 # CA1852: Seal internal types
 dotnet_diagnostic.CA1852.severity = none
 
+# CA1861: Avoid constant arrays as arguments
+dotnet_diagnostic.CA1861.severity = none
+
 # CA2201: Do not raise reserved exception types
 dotnet_diagnostic.CA2201.severity = none

--- a/tests/Mawosoft.MissingCoverage.Tests/ArgumentColumn.cs
+++ b/tests/Mawosoft.MissingCoverage.Tests/ArgumentColumn.cs
@@ -15,7 +15,7 @@ internal class ArgumentColumn
 
     public ArgumentColumn(IEnumerable<ArgumentCell> cells) => _cells = new(cells);
 
-    public ArgumentColumn(ArgumentCell cell) => (_cells = new()).Add(cell);
+    public ArgumentColumn(ArgumentCell cell) => (_cells = []).Add(cell);
 
     public void ResizeRows(int count)
     {
@@ -60,7 +60,7 @@ internal class ArgumentColumn
     public static ArgumentColumn Create(PropertyInfo propertyInfo, ArgumentMutations mutations)
     {
         ArgumentInfo argInfo = ArgumentInfo.Infos(propertyInfo.Name);
-        string[] oneEmptyString = new[] { "" };
+        string[] oneEmptyString = [""];
 
         IEnumerable<string> aliases = argInfo.Aliases.Count != 0
             ? (mutations.HasFlag(ArgumentMutations.Alias)
@@ -69,13 +69,13 @@ internal class ArgumentColumn
 
         IEnumerable<string> hyphens = argInfo.Aliases.Count != 0
             ? (mutations.HasFlag(ArgumentMutations.Hyphen)
-                ? new[] { "-", "--" } : new[] { "-" })
+                ? ["-", "--"] : ["-"])
             : oneEmptyString;
 
         int casingCount = mutations.HasFlag(ArgumentMutations.Casing) ? 3 : 1;
 
         // Use full permutations for hyphen, alias, and casing
-        List<string> prefixedAliases = new();
+        List<string> prefixedAliases = [];
         foreach (string alias in aliases)
         {
             if (alias.Length == 0)
@@ -107,10 +107,10 @@ internal class ArgumentColumn
 
         IEnumerable<string> delimiters = argInfo.Aliases.Count != 0 && !argInfo.IsSwitch
             ? (mutations.HasFlag(ArgumentMutations.Delimiter)
-                ? new[] { " ", ":", "=", ": ", "= " } : new[] { " " })
+                ? [" ", ":", "=", ": ", "= "] : [" "])
             : oneEmptyString;
 
-        List<(string, object?)> valuesAndTexts = new();
+        List<(string, object?)> valuesAndTexts = [];
         if (mutations.HasFlag(ArgumentMutations.InvalidValues) && !argInfo.IsSwitch)
         {
             valuesAndTexts.AddRange(argInfo.InvalidValues);
@@ -131,7 +131,7 @@ internal class ArgumentColumn
         int maxMutations =
             new[] { prefixedAliases.Count, delimiters.Count(), valuesAndTexts.Count }.Max();
 
-        List<ArgumentCell> cells = new();
+        List<ArgumentCell> cells = [];
         using RingEnumerator<string> aliasEnumerator = new(prefixedAliases);
         using RingEnumerator<string> delimiterEnumerator = new(delimiters);
         using RingEnumerator<(string, object?)> valueAndTextEnumerator = new(valuesAndTexts);

--- a/tests/Mawosoft.MissingCoverage.Tests/ArgumentInfo.cs
+++ b/tests/Mawosoft.MissingCoverage.Tests/ArgumentInfo.cs
@@ -25,7 +25,7 @@ internal class ArgumentInfo
         Aliases = new(SplitArguments(aliases));
         InvalidValues = new(
             new List<string>(SplitArguments(invalidValues)).ConvertAll(s => (s, (object?)null)));
-        ValidValues = new();
+        ValidValues = [];
         string[] valid = SplitArguments(validValues);
         Options options = new();
         // See notes on switch in OptionsTests.Clone_Succeeds
@@ -78,8 +78,8 @@ internal class ArgumentInfo
     static ArgumentInfo()
     {
         AssertOptionsMembers();
-        s_argumentInfos = new(new KeyValuePair<string, ArgumentInfo>[]
-        {
+        s_argumentInfos = new(
+        [
             // Intentionally not using nameof() here. If the name changes, other things might have changed as well.
             new ArgumentInfo("HitThreshold", "ht hit-threshold hitthreshold").KVP,
             new ArgumentInfo("CoverageThreshold", "ct coverage-threshold coveragethreshold", "0 70 100", "101 -1 bad").KVP,
@@ -93,7 +93,7 @@ internal class ArgumentInfo
             new ArgumentInfo("GlobPatterns", "").KVP,
             // Putting help last (it stops parsing) in case a user simply uses all descriptors
             new ArgumentInfo("ShowHelpOnly", "h help ?").KVP,
-        });
+        ]);
 
     }
 

--- a/tests/Mawosoft.MissingCoverage.Tests/ArgumentMatrix.cs
+++ b/tests/Mawosoft.MissingCoverage.Tests/ArgumentMatrix.cs
@@ -6,7 +6,7 @@ namespace Mawosoft.MissingCoverage.Tests;
 
 internal class ArgumentMatrix
 {
-    private readonly List<ArgumentColumn> _columns = new();
+    private readonly List<ArgumentColumn> _columns = [];
 
     public int ColumnCount => _columns.Count;
     public int RowCount => _columns.FirstOrDefault()?.Cells.Count ?? 0;
@@ -75,7 +75,7 @@ internal class ArgumentMatrix
     {
         ArgumentMatrix matrix = new();
         string[] propertyNames = SplitArguments(propertyNamesSpaceSeparated);
-        if (propertyNames.Length == 0) propertyNames = new[] { "*" };
+        if (propertyNames.Length == 0) propertyNames = ["*"];
         List<string> unusedPropertyNames = new(GetOptionsPropertyNames(PropertySelector.All));
         foreach (string propertyName in propertyNames)
         {
@@ -96,7 +96,7 @@ internal class ArgumentMatrix
                     matrix.AddColumn(new ArgumentColumn(new ArgumentCell("--", null)));
                     break;
                 default:
-                    AddColumns(new[] { propertyName });
+                    AddColumns([propertyName]);
                     break;
             }
         }

--- a/tests/Mawosoft.MissingCoverage.Tests/ArgumentRow.cs
+++ b/tests/Mawosoft.MissingCoverage.Tests/ArgumentRow.cs
@@ -13,7 +13,7 @@ internal class ArgumentRow
 
     public ArgumentRow(IEnumerable<ArgumentCell> cells) => _cells = cells.ToList();
 
-    public ArgumentRow(ArgumentCell cell) => (_cells = new()).Add(cell);
+    public ArgumentRow(ArgumentCell cell) => (_cells = []).Add(cell);
 
     public override string ToString() => string.Join(' ', ToArguments());
 

--- a/tests/Mawosoft.MissingCoverage.Tests/CoberturaParserTests.SimpleCoberturaParser.cs
+++ b/tests/Mawosoft.MissingCoverage.Tests/CoberturaParserTests.SimpleCoberturaParser.cs
@@ -15,7 +15,7 @@ public partial class CoberturaParserTests
         Regex regexCoverage = new(@"\((\d+)/(\d+)\)", RegexOptions.CultureInvariant);
 
         CoverageResult result = new(reportFilePath);
-        List<string> sourceDirectories = new();
+        List<string> sourceDirectories = [];
 
         XPathNavigator navi = document.CreateNavigator();
         XPathNavigator? node = navi.SelectSingleNode("/coverage");

--- a/tests/Mawosoft.MissingCoverage.Tests/CoberturaParserTests.cs
+++ b/tests/Mawosoft.MissingCoverage.Tests/CoberturaParserTests.cs
@@ -25,7 +25,7 @@ public partial class CoberturaParserTests
         int pos = exception.LinePosition - fileLine.Length + (fileLine = fileLine.TrimStart()).Length;
         string[] elementLines = report.FirstInvalidElement!
             .ToString()
-            .Split(new[] { "\r\n", "\n", "\r" }, StringSplitOptions.TrimEntries);
+            .Split(["\r\n", "\n", "\r"], StringSplitOptions.TrimEntries);
         string elementLine;
         int expectedPos;
         if (fileLine.StartsWith("</", StringComparison.Ordinal))
@@ -90,10 +90,10 @@ public partial class CoberturaParserTests
     [InlineData(null)]
     [InlineData("")]
     [InlineData("  ")]
-    public void Ctor_InvalidReportFilePath_Throws(string reportFilePath)
+    public void Ctor_InvalidReportFilePath_Throws(string? reportFilePath)
     {
         ArgumentException ex = Assert.ThrowsAny<ArgumentException>(
-            () => _ = new CoverageResult(reportFilePath));
+            () => _ = new CoverageResult(reportFilePath!));
         Assert.Equal("reportFilePath", ex.ParamName);
     }
 
@@ -201,14 +201,14 @@ public partial class CoberturaParserTests
     [InlineData("coverage", "profilerVersion", "1.2.3", "driverVersion", "1.2.3")]
     public void Parse_NonCoberturaRoot_Throws(params string[] rootParams)
     {
-        List<(string, string)> attributes = new();
+        List<(string, string)> attributes = [];
         for (int i = 1; i + 1 < rootParams.Length; i += 2)
         {
             attributes.Add((rootParams[i], rootParams[i + 1]));
         }
         using TempFile tempFile = new();
         CoberturaReportBuilder report = new CoberturaReportBuilder(tempFile.FullPath)
-            .AddRoot(rootParams[0], attributes.ToArray())
+            .AddRoot(rootParams[0], [.. attributes])
             .AddMinimalDefaults()
             .Save();
         report.FirstInvalidElement = report.Root; // Builder doesn't validate custom root.
@@ -451,7 +451,7 @@ public partial class CoberturaParserTests
     [Fact]
     public void Parse_ValidLineNumber_Succeeds()
     {
-        int[] numbers = new[] { 1, 27, SourceFileInfo.MaxLineNumber, 2, 6 };
+        int[] numbers = [1, 27, SourceFileInfo.MaxLineNumber, 2, 6];
         using TempFile tempFile = new();
         CoberturaReportBuilder report = new CoberturaReportBuilder(tempFile.FullPath)
             .AddSources()
@@ -527,7 +527,7 @@ public partial class CoberturaParserTests
     [Fact]
     public void Parse_ValidHits_Succeeds()
     {
-        int[] hits = new[] { 0, 1, 2, 32, 457 };
+        int[] hits = [0, 1, 2, 32, 457];
         using TempFile tempFile = new();
         CoberturaReportBuilder report = new CoberturaReportBuilder(tempFile.FullPath)
             .AddSources()

--- a/tests/Mawosoft.MissingCoverage.Tests/CoberturaReportBuilder.cs
+++ b/tests/Mawosoft.MissingCoverage.Tests/CoberturaReportBuilder.cs
@@ -10,7 +10,7 @@ internal class CoberturaReportBuilder
     public static readonly XDocumentType DefaultDTD = new("coverage", null, "http://cobertura.sourceforge.net/xml/coverage-04.dtd", null!);
 
     private DateTime _reportTimestamp;
-    private readonly List<string> _normalizedSourceDirectories = new();
+    private readonly List<string> _normalizedSourceDirectories = [];
     private XElement? _root;
     private XElement? _sources;
     private XElement? _packages;

--- a/tests/Mawosoft.MissingCoverage.Tests/CoverageResultTests.cs
+++ b/tests/Mawosoft.MissingCoverage.Tests/CoverageResultTests.cs
@@ -28,10 +28,10 @@ public class CoverageResultTests
     [InlineData(null)]
     [InlineData("")]
     [InlineData("  ")]
-    public void Ctor_InvalidReportFilePath_Throws(string reportFilePath)
+    public void Ctor_InvalidReportFilePath_Throws(string? reportFilePath)
     {
         ArgumentException ex = Assert.ThrowsAny<ArgumentException>(
-            () => _ = new CoverageResult(reportFilePath));
+            () => _ = new CoverageResult(reportFilePath!));
         Assert.Equal("reportFilePath", ex.ParamName);
     }
 

--- a/tests/Mawosoft.MissingCoverage.Tests/LineInfoTests.cs
+++ b/tests/Mawosoft.MissingCoverage.Tests/LineInfoTests.cs
@@ -65,7 +65,7 @@ public class LineInfoTests
     {
         public Merge_TheoryData()
         {
-            LineInfoMergeData mergeData = new();
+            LineInfoMergeData mergeData = [];
             foreach ((LineInfo target, LineInfo other, LineInfo expected) in mergeData)
             {
                 Add(target, other, expected);

--- a/tests/Mawosoft.MissingCoverage.Tests/OptionValueTests.cs
+++ b/tests/Mawosoft.MissingCoverage.Tests/OptionValueTests.cs
@@ -145,41 +145,41 @@ public class OptionValueTests
     [ClassData(typeof(TypeAndValue_TheoryData))]
     public void Ctor_DefaultValue(Type type, object value)
     {
-        InvokeTypedTest(type, new object[] { value });
+        InvokeTypedTest(type, [value]);
     }
 
     [Theory]
     [ClassData(typeof(TypeAndValue_TheoryData))]
     public void Value_Roundtrip(Type type, object value)
     {
-        InvokeTypedTest(type, new object[] { value });
+        InvokeTypedTest(type, [value]);
     }
 
     [Theory]
     [ClassData(typeof(TypeAndValue_TheoryData))]
     public void ToString_AddsIsSetMarker(Type type, object value)
     {
-        InvokeTypedTest(type, new object[] { value });
+        InvokeTypedTest(type, [value]);
     }
 
     [Theory]
     [ClassData(typeof(TypeAndValue_TheoryData))]
     public void ImplicitOperator_T(Type type, object value)
     {
-        InvokeTypedTest(type, new object[] { value });
+        InvokeTypedTest(type, [value]);
     }
 
     [Theory]
     [ClassData(typeof(TypeAndValue_TheoryData))]
     public void ImplicitOperator_OptionValueT(Type type, object value)
     {
-        InvokeTypedTest(type, new object[] { value });
+        InvokeTypedTest(type, [value]);
     }
 
     [Theory]
     [ClassData(typeof(TypeAndValue_TheoryData))]
     public void AssignStruct_CopiesStruct(Type type, object value)
     {
-        InvokeTypedTest(type, new object[] { value });
+        InvokeTypedTest(type, [value]);
     }
 }

--- a/tests/Mawosoft.MissingCoverage.Tests/OptionsTests.cs
+++ b/tests/Mawosoft.MissingCoverage.Tests/OptionsTests.cs
@@ -43,7 +43,7 @@ public class OptionsTests
         Options actual = new();
         actual.ParseCommandLineArguments(null!);
         AssertOptionsEqual(expected, actual);
-        actual.ParseCommandLineArguments(Array.Empty<string>());
+        actual.ParseCommandLineArguments([]);
         AssertOptionsEqual(expected, actual);
     }
 
@@ -93,7 +93,7 @@ public class OptionsTests
     internal void ParseCmdLine_Verbosity(string actualValue, VerbosityLevel expectedValue)
     {
         Options expected = new() { Verbosity = expectedValue };
-        string[] args = { "-v", actualValue };
+        string[] args = ["-v", actualValue];
         Options actual = new();
         actual.ParseCommandLineArguments(args);
         AssertOptionsEqual(expected, actual);
@@ -363,8 +363,8 @@ public class OptionsTests
                 break;
             case List<string>:
                 Assert.Equal(nameof(Options.GlobPatterns), property.Name);
-                source.GlobPatterns.AddRange(new[] { "glob1", "glob2" });
-                expected.GlobPatterns.AddRange(new[] { "glob1", "glob2" });
+                source.GlobPatterns.AddRange(["glob1", "glob2"]);
+                expected.GlobPatterns.AddRange(["glob1", "glob2"]);
                 break;
             default:
                 // Unexpected type; this gives the full type name

--- a/tests/Mawosoft.MissingCoverage.Tests/ProgramTestHelper.cs
+++ b/tests/Mawosoft.MissingCoverage.Tests/ProgramTestHelper.cs
@@ -118,7 +118,7 @@ internal static class ProgramTestHelper
     {
         int fileId = 1;
         string? content = null;
-        List<string> files = new();
+        List<string> files = [];
         while (files.Count < reportFileCount)
         {
             for (int level1 = 1; level1 <= 2 && files.Count < reportFileCount; level1++)

--- a/tests/Mawosoft.MissingCoverage.Tests/ProgramTests.Run.cs
+++ b/tests/Mawosoft.MissingCoverage.Tests/ProgramTests.Run.cs
@@ -54,7 +54,7 @@ public partial class ProgramTests
         using TempDirectory tempDirectory = new();
         List<string> files = CreateMinimalReportFiles(tempDirectory, 1);
         using RedirectWrapper wrapper = new();
-        int exitCode = wrapper.Program.Run(new string[] { files[0] });
+        int exitCode = wrapper.Program.Run([files[0]]);
         Assert.Equal(0, exitCode);
         AssertAppTitle(wrapper);
         AssertInputTitle(wrapper);
@@ -84,7 +84,7 @@ public partial class ProgramTests_NoParallelTests
             using StringWriter error = new();
             Console.SetOut(output);
             Console.SetError(error);
-            int exitCode = Program.Main(new string[] { reportName });
+            int exitCode = Program.Main([reportName]);
             Assert.Equal(0, exitCode);
             Assert.Equal(0, error.GetStringBuilder().Length);
             string approvedFile = Path.Combine(TestDataDirectory.GetTestDataDirectory(), "approved", reportName + ".txt");

--- a/tests/Mawosoft.MissingCoverage.Tests/RedirectWrapper.cs
+++ b/tests/Mawosoft.MissingCoverage.Tests/RedirectWrapper.cs
@@ -38,7 +38,7 @@ internal sealed class RedirectWrapper : IDisposable
 
     public RedirectWrapper(Program program)
     {
-        _lines = new();
+        _lines = [];
         _out = new(_lines, "1>");
         _error = new(_lines, "2>");
         program.Out = _out;
@@ -54,20 +54,13 @@ internal sealed class RedirectWrapper : IDisposable
 
     public void Dispose() => Close();
 
-    private class SyncLineWriter : TextWriter
+    private class SyncLineWriter(List<string> target, string prefix) : TextWriter
     {
-        private readonly List<string> _target;
-        private readonly string _prefix;
-        private volatile bool _isopen;
+        private readonly List<string> _target = target;
+        private readonly string _prefix = prefix;
+        private volatile bool _isopen = true;
 
         public bool IsOpen => _isopen;
-
-        public SyncLineWriter(List<string> target, string prefix)
-        {
-            _target = target;
-            _prefix = prefix;
-            _isopen = true;
-        }
 
         public override Encoding Encoding => Encoding.Unicode;
 

--- a/tests/Mawosoft.MissingCoverage.Tests/SourceFileInfoTests.cs
+++ b/tests/Mawosoft.MissingCoverage.Tests/SourceFileInfoTests.cs
@@ -18,10 +18,10 @@ public class SourceFileInfoTests
     [InlineData(null)]
     [InlineData("")]
     [InlineData("  ")]
-    public void Ctor_InvalidSourceFilePath_Throws(string sourceFilePath)
+    public void Ctor_InvalidSourceFilePath_Throws(string? sourceFilePath)
     {
         ArgumentException ex = Assert.ThrowsAny<ArgumentException>(
-            () => _ = new SourceFileInfo(sourceFilePath, DateTime.UtcNow));
+            () => _ = new SourceFileInfo(sourceFilePath!, DateTime.UtcNow));
         Assert.Equal(nameof(SourceFileInfo.SourceFilePath), ex.ParamName, ignoreCase: true);
     }
 
@@ -43,12 +43,12 @@ public class SourceFileInfoTests
     [InlineData(null)]
     [InlineData("")]
     [InlineData("  ")]
-    public void SourceFilePath_InvalidValue_Throws(string sourceFilePath)
+    public void SourceFilePath_InvalidValue_Throws(string? sourceFilePath)
     {
         string initialPath = "foo";
         SourceFileInfo info = new(initialPath, DateTime.UtcNow);
         ArgumentException ex = Assert.ThrowsAny<ArgumentException>(
-            () => info.SourceFilePath = sourceFilePath);
+            () => info.SourceFilePath = sourceFilePath!);
         Assert.Equal(nameof(SourceFileInfo.SourceFilePath), ex.ParamName);
         Assert.Equal(initialPath, info.SourceFilePath);
     }
@@ -236,7 +236,7 @@ public class SourceFileInfoTests
             SourceFileInfo targetFile2 = new(otherFile1.SourceFilePath, otherFile1.ReportTimestamp);
             SourceFileInfo otherFile2 = new(targetFile1.SourceFilePath, targetFile1.ReportTimestamp);
             SourceFileInfo expectedFile2 = new(targetFile2.SourceFilePath, targetFile2.ReportTimestamp);
-            LineInfoMergeData mergeData = new();
+            LineInfoMergeData mergeData = [];
             int lineNumber = 0;
             foreach ((LineInfo target, LineInfo other, LineInfo expected) in mergeData)
             {
@@ -282,7 +282,7 @@ public class SourceFileInfoTests
     internal void LineSequences_Succeeds()
     {
         SourceFileInfo source = new("somefile", DateTime.UtcNow);
-        List<(int, int)> expected = new();
+        List<(int, int)> expected = [];
         Assert.Equal(expected, source.LineSequences());
         // Force LastLineNumber = 5, but clear line afterwards
         source.AddOrMergeLine(5, new() { Hits = 0 });

--- a/tests/Mawosoft.MissingCoverage.Tests/TempFile.cs
+++ b/tests/Mawosoft.MissingCoverage.Tests/TempFile.cs
@@ -17,14 +17,14 @@ public sealed class TempFile : IDisposable
     {
         FullPath = GetRandomTempFilePath(memberName, lineNumber);
         AutoDelete = true;
-        File.WriteAllBytes(FullPath, Array.Empty<byte>());
+        File.WriteAllBytes(FullPath, []);
     }
 
     public TempFile(string path, bool autoDelete)
     {
         FullPath = Path.GetFullPath(path);
         AutoDelete = autoDelete;
-        File.WriteAllBytes(FullPath, Array.Empty<byte>());
+        File.WriteAllBytes(FullPath, []);
     }
 
     ~TempFile()

--- a/tests/benchmarks/EnumBenchmarks/Program.cs
+++ b/tests/benchmarks/EnumBenchmarks/Program.cs
@@ -27,7 +27,7 @@ namespace EnumBenchmarks
         [Benchmark(Baseline = true)]
         [Arguments(2)]
         [Arguments((int)VerbosityLevel.Diagnostic + 1)]
-        public bool IsDefinedGeneric(int value) => Enum.IsDefined((VerbosityLevel) value);
+        public bool IsDefinedGeneric(int value) => Enum.IsDefined((VerbosityLevel)value);
 
         [Benchmark]
         [Arguments(2)]

--- a/tests/benchmarks/LineInfoBenchmarks/ArrayExtensions.cs
+++ b/tests/benchmarks/LineInfoBenchmarks/ArrayExtensions.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) 2021-2023 Matthias Wolf, Mawosoft.
 
 using System;
-using System.Runtime.CompilerServices;
 
 namespace LineInfoBenchmarks
 {

--- a/tests/benchmarks/LineInfoBenchmarks/LineInfoEqualsSequenceEnumBenchmarks.cs
+++ b/tests/benchmarks/LineInfoBenchmarks/LineInfoEqualsSequenceEnumBenchmarks.cs
@@ -6,8 +6,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using System.Text;
-using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
 using Mawosoft.Extensions.BenchmarkDotNet;
 

--- a/tests/benchmarks/LineInfoBenchmarks/ParamGroupOrderer.cs
+++ b/tests/benchmarks/LineInfoBenchmarks/ParamGroupOrderer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021-2023 Matthias Wolf, Mawosoft.
+// Copyright (c) 2021-2023 Matthias Wolf, Mawosoft.
 
 using System;
 using System.Collections.Generic;
@@ -33,7 +33,7 @@ namespace LineInfoBenchmarks
 
         public bool SeparateLogicalGroups => _inner.SeparateLogicalGroups;
 
-        public IEnumerable<BenchmarkCase> GetExecutionOrder(ImmutableArray<BenchmarkCase> benchmarksCase, IEnumerable<BenchmarkLogicalGroupRule> order) => _inner.GetExecutionOrder(benchmarksCase, order);
+        public IEnumerable<BenchmarkCase> GetExecutionOrder(ImmutableArray<BenchmarkCase> benchmarksCase, IEnumerable<BenchmarkLogicalGroupRule>? order) => _inner.GetExecutionOrder(benchmarksCase, order);
         public string? GetHighlightGroupKey(BenchmarkCase benchmarkCase)
             => benchmarkCase.Parameters.Items.FirstOrDefault(
                    p => p.Name.Equals("group", StringComparison.OrdinalIgnoreCase))?.Value?.ToString()
@@ -44,7 +44,7 @@ namespace LineInfoBenchmarks
                    p => p.Name.Equals("group", StringComparison.OrdinalIgnoreCase))?.Value?.ToString()
                ?? _inner.GetLogicalGroupKey(allBenchmarksCases, benchmarkCase);
 
-        public IEnumerable<IGrouping<string, BenchmarkCase>> GetLogicalGroupOrder(IEnumerable<IGrouping<string, BenchmarkCase>> logicalGroups, IEnumerable<BenchmarkLogicalGroupRule> order) => _inner.GetLogicalGroupOrder(logicalGroups, order);
+        public IEnumerable<IGrouping<string, BenchmarkCase>> GetLogicalGroupOrder(IEnumerable<IGrouping<string, BenchmarkCase>> logicalGroups, IEnumerable<BenchmarkLogicalGroupRule>? order) => _inner.GetLogicalGroupOrder(logicalGroups, order);
         public IEnumerable<BenchmarkCase> GetSummaryOrder(ImmutableArray<BenchmarkCase> benchmarksCases, Summary summary) => _inner.GetSummaryOrder(benchmarksCases, summary);
     }
 }

--- a/tests/benchmarks/XmlBenchmarks/CoberturaFileInfo.cs
+++ b/tests/benchmarks/XmlBenchmarks/CoberturaFileInfo.cs
@@ -5,9 +5,9 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using System.Xml.XPath;
-using System.Linq;
 
 namespace XmlBenchmarks
 {
@@ -58,7 +58,7 @@ namespace XmlBenchmarks
             // Note that branch="False/True" in coverlet and "false/true" in FCC merged.
             // The set of available XPath functions is limited, there is no lower-case(), for example.
             int branchTrue = 0, branchFalse = 0;
-            foreach(XPathNavigator node in navi.Select(classLinesPath + "/@branch"))
+            foreach (XPathNavigator node in navi.Select(classLinesPath + "/@branch"))
             {
                 switch (node.Value.ToLowerInvariant())
                 {
@@ -139,7 +139,7 @@ namespace XmlBenchmarks
                         }
                     }
                 }
-                
+
             }
             if (tablePaddingOptions != TablePaddingOptions.None)
             {
@@ -167,7 +167,7 @@ namespace XmlBenchmarks
             string[][] table = ToTable(fileInfos, tablePaddingOptions, cultureInfo, numberFormat);
             if (table.Length == 0)
                 return null;
-            List<string> rows = table.Select(row => "| "+ string.Join(" | ", row) + " |").ToList();
+            List<string> rows = table.Select(row => "| " + string.Join(" | ", row) + " |").ToList();
             string[] separatorRow = table[0].Select(
                 cell => string.Concat(string.Empty.PadRight(cell.Length + 1, '-') + ":")).ToArray();
             separatorRow[0] = separatorRow[0].Substring(0, separatorRow[0].Length - 1) + " ";

--- a/tests/benchmarks/XmlBenchmarks/TestFiles.cs
+++ b/tests/benchmarks/XmlBenchmarks/TestFiles.cs
@@ -4,8 +4,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Xml;
 using System.Xml.XPath;
 
@@ -40,7 +38,7 @@ namespace XmlBenchmarks
         public static List<string> GetFilePaths()
         {
             if (TestFileSelector is FileSelector.Large or FileSelector.All or FileSelector.AllKnown
-                && MockFileSizeMB > 0  && s_knownFilePaths[(int)FileSelector.Large] == null)
+                && MockFileSizeMB > 0 && s_knownFilePaths[(int)FileSelector.Large] == null)
             {
                 CreateMockFile();
             }
@@ -73,7 +71,7 @@ namespace XmlBenchmarks
             // will reuse the argument. However, XPathDocument and other stream consumers will dispose the stream
             // after reading. We return a byte[] array instead. The MemoryStream constructor only contains a few
             // variable assignments.
-            foreach(string filePath in GetFilePaths())
+            foreach (string filePath in GetFilePaths())
             {
                 yield return new FileBytesWrapper(File.ReadAllBytes(filePath), filePath);
             }
@@ -154,7 +152,7 @@ namespace XmlBenchmarks
                         break;
                     case (int)FileSelector.Large:
                         if (MockFileSizeMB > 0
-                            && Math.Round(new FileInfo(filePath).Length / (1024d*1024d)) == MockFileSizeMB)
+                            && Math.Round(new FileInfo(filePath).Length / (1024d * 1024d)) == MockFileSizeMB)
                         {
                             s_knownFilePaths[i] = filePath;
                         }


### PR DESCRIPTION
- Bump dotnet SDK to 8.0.202 and fix resulting analyzer warnings.
- Update package dependencies. Closes #115.
- Remove unnecessary transitive pinnings.